### PR TITLE
Add rate limit to prevent radio flooding

### DIFF
--- a/HA_BluePrint_ZeroFeedIn.yaml
+++ b/HA_BluePrint_ZeroFeedIn.yaml
@@ -39,7 +39,7 @@ blueprint:
       selector:
         number:
           min: 5
-          max: 120
+          max: 60
           unit_of_measurement: 's'
           step: 5.0
     MaxInverterPower:
@@ -125,8 +125,8 @@ variables:
   new_setpoint: "{% set setpoint = gridsum + modifier_setpoint|float(0) + states(currentlimit)|float(0) -5 %}{% if setpoint > upperlimit -%}{% set setpoint = upperlimit %}{% elif setpoint < lowerlimit %}{% set setpoint = lowerlimit %}{%- endif %}{{setpoint}}"
   new_setpoint_mode2: '{% set setpoint = gridsum + modifier_setpoint|float(0) + pvgeneration + 5 %}{% if setpoint > upperlimit -%}{% set setpoint = upperlimit %}{% elif setpoint < lowerlimit %}{% set setpoint = lowerlimit %}{%- endif %}{{setpoint}}'
 trigger:
-- platform: time_pattern
-  seconds: "/{{triggerinterval}}"
+  - platform: template 
+    value_template: "{{ now().second % states('triggerinterval')|int(2) == 0 }}"
 condition:
 - condition: template
   value_template: '{{ states(inverteronline) == "on"}}'

--- a/HA_BluePrint_ZeroFeedIn.yaml
+++ b/HA_BluePrint_ZeroFeedIn.yaml
@@ -110,7 +110,7 @@ blueprint:
         entity:
 
 variables:
-  triggerinterval: "/{{TriggerInterval}}"
+  triggerinterval: !input TriggerInterval
   lowerlimit: !input 'MinInverterPower'
   upperlimit: !input 'MaxInverterPower'
   currentlimit: !input 'NonPersistantLimit'
@@ -126,7 +126,7 @@ variables:
   new_setpoint_mode2: '{% set setpoint = gridsum + modifier_setpoint|float(0) + pvgeneration + 5 %}{% if setpoint > upperlimit -%}{% set setpoint = upperlimit %}{% elif setpoint < lowerlimit %}{% set setpoint = lowerlimit %}{%- endif %}{{setpoint}}'
 trigger:
 - platform: time_pattern
-  seconds: "{{triggerinterval}}"
+  seconds: "/{{triggerinterval}}"
 condition:
 - condition: template
   value_template: '{{ states(inverteronline) == "on"}}'

--- a/HA_BluePrint_ZeroFeedIn.yaml
+++ b/HA_BluePrint_ZeroFeedIn.yaml
@@ -110,7 +110,7 @@ blueprint:
         entity:
 
 variables:
-  triggerinterval: "{{TriggerInterval}}" 'TriggerInterval'
+  triggerinterval: !input 'TriggerInterval'
   lowerlimit: !input 'MinInverterPower'
   upperlimit: !input 'MaxInverterPower'
   currentlimit: !input 'NonPersistantLimit'

--- a/HA_BluePrint_ZeroFeedIn.yaml
+++ b/HA_BluePrint_ZeroFeedIn.yaml
@@ -131,11 +131,11 @@ condition:
 - condition: template
   value_template: '{{ states(inverteronline) == "on"}}'
 - condition: template
-  value_template: '{{(new_setpoint - states(currentlimit)|float(0))|abs > 5}}'
-- condition: template
   value_template: |
     {%- set last = state_attr(this.entity_id, 'last_triggered') %}
     {{ last is not none and now() - last > timedelta(seconds=triggerinterval) }}
+- condition: template
+  value_template: '{{(new_setpoint - states(currentlimit)|float(0))|abs > 5}}'
 action:
   - service: logbook.log
     data_template:

--- a/HA_BluePrint_ZeroFeedIn.yaml
+++ b/HA_BluePrint_ZeroFeedIn.yaml
@@ -135,7 +135,7 @@ condition:
 - condition: template
   value_template: |
     {%- set last = state_attr(this.entity_id, 'last_triggered') %}
-    {{ last is not none and now() - last > timedelta(seconds={{triggerinterval}}) }}
+    {{ last is not none and now() - last > timedelta(seconds=triggerinterval) }}
 action:
   - service: logbook.log
     data_template:

--- a/HA_BluePrint_ZeroFeedIn.yaml
+++ b/HA_BluePrint_ZeroFeedIn.yaml
@@ -39,7 +39,7 @@ blueprint:
       selector:
         number:
           min: 5
-          max: 60
+          max: 120
           unit_of_measurement: 's'
           step: 5.0
     MaxInverterPower:
@@ -110,7 +110,7 @@ blueprint:
         entity:
 
 variables:
-  triggerinterval: !input TriggerInterval
+  triggerinterval: "{{TriggerInterval}}" 'TriggerInterval'
   lowerlimit: !input 'MinInverterPower'
   upperlimit: !input 'MaxInverterPower'
   currentlimit: !input 'NonPersistantLimit'
@@ -125,13 +125,17 @@ variables:
   new_setpoint: "{% set setpoint = gridsum + modifier_setpoint|float(0) + states(currentlimit)|float(0) -5 %}{% if setpoint > upperlimit -%}{% set setpoint = upperlimit %}{% elif setpoint < lowerlimit %}{% set setpoint = lowerlimit %}{%- endif %}{{setpoint}}"
   new_setpoint_mode2: '{% set setpoint = gridsum + modifier_setpoint|float(0) + pvgeneration + 5 %}{% if setpoint > upperlimit -%}{% set setpoint = upperlimit %}{% elif setpoint < lowerlimit %}{% set setpoint = lowerlimit %}{%- endif %}{{setpoint}}'
 trigger:
-  - platform: template 
-    value_template: "{{ now().second % states('triggerinterval')|int(2) == 0 }}"
+- platform: state
+  entity_id: !input 'GridPowerMeters'
 condition:
 - condition: template
   value_template: '{{ states(inverteronline) == "on"}}'
 - condition: template
   value_template: '{{(new_setpoint - states(currentlimit)|float(0))|abs > 5}}'
+- condition: template
+  value_template: |
+    {%- set last = state_attr(this.entity_id, 'last_triggered') %}
+    {{ last is not none and now() - last > timedelta(seconds={{triggerinterval}}) }}
 action:
   - service: logbook.log
     data_template:

--- a/HA_BluePrint_ZeroFeedIn.yaml
+++ b/HA_BluePrint_ZeroFeedIn.yaml
@@ -126,7 +126,7 @@ variables:
   new_setpoint_mode2: '{% set setpoint = gridsum + modifier_setpoint|float(0) + pvgeneration + 5 %}{% if setpoint > upperlimit -%}{% set setpoint = upperlimit %}{% elif setpoint < lowerlimit %}{% set setpoint = lowerlimit %}{%- endif %}{{setpoint}}'
 trigger:
 - platform: time_pattern
-  seconds: !input 'triggerinterval'
+  seconds: "{{triggerinterval}}"
 condition:
 - condition: template
   value_template: '{{ states(inverteronline) == "on"}}'

--- a/HA_BluePrint_ZeroFeedIn.yaml
+++ b/HA_BluePrint_ZeroFeedIn.yaml
@@ -2,7 +2,7 @@ blueprint:
   name: Control PV Limit to avoid exporting to the grid
   description: > 
     # Zero Feed In Automation
-    **Version: 0.0.3**
+    **Version: 0.0.4**
     
     # Summary
     This automation will react on changes of energy imported or exported from the grid.
@@ -32,6 +32,16 @@ blueprint:
     Check the github repository: https://github.com/AndreBott83/HA_Zero_PV_Grid_Feed_in
   domain: automation
   input:
+    TriggerInterval:
+      name: Interval trigger
+      description: Interval of which the automation will be triggered and a limit could be set in seconds
+      default: 15
+      selector:
+        number:
+          min: 5
+          max: 120
+          unit_of_measurement: 's'
+          step: 5.0
     MaxInverterPower:
       name: Inverter upper limit
       description: Define the maximum power the inverter can deliver in W
@@ -100,6 +110,7 @@ blueprint:
         entity:
 
 variables:
+  triggerinterval: "/{{TriggerInterval}}"
   lowerlimit: !input 'MinInverterPower'
   upperlimit: !input 'MaxInverterPower'
   currentlimit: !input 'NonPersistantLimit'
@@ -114,9 +125,8 @@ variables:
   new_setpoint: "{% set setpoint = gridsum + modifier_setpoint|float(0) + states(currentlimit)|float(0) -5 %}{% if setpoint > upperlimit -%}{% set setpoint = upperlimit %}{% elif setpoint < lowerlimit %}{% set setpoint = lowerlimit %}{%- endif %}{{setpoint}}"
   new_setpoint_mode2: '{% set setpoint = gridsum + modifier_setpoint|float(0) + pvgeneration + 5 %}{% if setpoint > upperlimit -%}{% set setpoint = upperlimit %}{% elif setpoint < lowerlimit %}{% set setpoint = lowerlimit %}{%- endif %}{{setpoint}}'
 trigger:
-- platform: state
-  entity_id: !input 'GridPowerMeters'
-
+- platform: time_pattern
+  seconds: !input 'triggerinterval'
 condition:
 - condition: template
   value_template: '{{ states(inverteronline) == "on"}}'


### PR DESCRIPTION
Hi,

i have tested your zero feed in automation but had issues with the radio so it was flooded by too many adjustments of the limit.

So i have tried to implement some kind of rate limiter.

The idea is to only allow setting the limit every x seconds so the radio is not going to be blocked.

What do you think? 

Best regards
eloo